### PR TITLE
Support null speed on ReferenceTarget

### DIFF
--- a/msg/ReferenceTarget.msg
+++ b/msg/ReferenceTarget.msg
@@ -1,4 +1,6 @@
 # PoseStamped data for reference target pose
+float32 NO_SPEED_MEASUREMENT = -999.0
+
 geographic_msgs/GeoPoseStamped pose
 
 # Linear speed in m/s

--- a/msg/ReferenceTarget.msg
+++ b/msg/ReferenceTarget.msg
@@ -1,6 +1,10 @@
-# PoseStamped data for reference target pose
-float32 NO_SPEED_MEASUREMENT = -999.0
+# Constant representing that the value in question couldn't be measured
+# This often applied speed or heading/yaw for example in single-antenna GPS
+# For orientation, use NO_MEASUREMENT as the `w` value of the quaternion
+# This value is arbitrary and should be used by name rather than by value, but it's chosen to be exactly-representable in a float32 so there aren't floating point comparison issues
+float32 NO_MEASUREMENT = -9999.5
 
+# PoseStamped data for reference target pose
 geographic_msgs/GeoPoseStamped pose
 
 # Linear speed in m/s


### PR DESCRIPTION
Add a sentinel value for ReferenceTarget::measured_speed_m_s that indicates no measurement is available, so no value is provided