### PR TITLE
Add in vehicle joint command service

### DIFF
--- a/srv/VehicleJointCommand.srv
+++ b/srv/VehicleJointCommand.srv
@@ -1,0 +1,27 @@
+## Request
+# Commands for a specific joint, assumes it will get to what you target async
+# If you want to use a command, set the value to something other than UNUSED
+# Only one command type will be used, priority is position, then velocity, then effort. If you set more than one, the priority will be used to determine which one is used.
+
+float64 UNUSED=-999999
+
+# Target position for the joint command
+float64 target_position -999999
+
+# Target velocity for the joint command
+float64 target_velocity -999999
+
+# Target effort for the joint command
+float64 target_effort -999999
+
+# Timeout for the command being sent
+uint32 tiemout_ms 5000
+
+---
+## Response
+
+# Indicate successful run of service
+bool success
+
+# Error messages
+string error


### PR DESCRIPTION
Matching how we think of joints but being explicit, we enable ability to send position, velocity, or effort to a specific vehicle joint. 

The idea is that this service can be created for each similarly controllable joint. When able, the vehicle will run the command as requested for the <timeout> amount of time (do 0.5 effort for 30seconds type commands become enabled). It also binds PID type commands (position and velocity) under some timeout (set to unused if no want to use)

Position, Velocity, Effort can be commanded
Success returns whether vehicle will attempt to implement or not
Error explains why if not